### PR TITLE
Update launch_openpilot.sh

### DIFF
--- a/launch_openpilot.sh
+++ b/launch_openpilot.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
-export ATHENA_HOST="wss://connect-ws.duckdns.org"
-export API_HOST="https://connect-api.duckdns.org"
+export ATHENA_HOST="wss://athena.konik.ai"
+export API_HOST="https://api.konik.ai"
 export PASSIVE="0"
 exec ./launch_chffrplus.sh
 


### PR DESCRIPTION
**Description**

The old duckdns connect server causes Comma devices to hang on boot, showing "registering device". This change updates the server env variables to point to the current konik server. 

**Verification**

This is a similar change to what was done to mazda-master, which did not boot before the change, and now successfully boots after the change. 