### PR TITLE
fix: don't overwrite RecordFront on re-training

### DIFF
--- a/selfdrive/ui/qt/offroad/onboarding.cc
+++ b/selfdrive/ui/qt/offroad/onboarding.cc
@@ -35,7 +35,7 @@ void TrainingGuide::mouseReleaseEvent(QMouseEvent *e) {
   };
 
   if (contains(boundingRect[currentIndex], e->pos())) {
-    if (currentIndex == 9) {
+    if (currentIndex == 9 && Params().get("RecordFront").empty()) {
       const QRect yes = QRect(707, 804, 531, 164);
       Params().putBool("RecordFront", contains(yes, e->pos()));
     }


### PR DESCRIPTION
## Description

Onboarding step 9 unconditionally writes `RecordFront` every time
training triggers. When a FrogPilot update bumps `TrainingVersion`,
the user gets re-onboarded and their driver camera recording
preference gets silently overwritten based on where they click
through the training screens.

This is frustrating if you've turned off driver camera recording
in settings - it gets re-enabled without any indication.

## Fix

Only set `RecordFront` on first-time setup (when the param doesn't
exist yet). On re-training, the param already has a value so we
skip the write and preserve the user's preference.

```cpp
// before: always writes
if (currentIndex == 9) {
    Params().putBool("RecordFront", contains(yes, e->pos()));
}

// after: only on first setup
if (currentIndex == 9 && Params().get("RecordFront").empty()) {
    Params().putBool("RecordFront", contains(yes, e->pos()));
}
```

## Alternative approach

A more aggressive option would be to remove the `RecordFront` write
from onboarding entirely, since there's already a dedicated toggle
in settings ("Record and Upload Driver Camera"). This would simplify
onboarding but would mean new users have to find the toggle themselves.

## Verification

Reproduced on a comma 3 running mazda-frogpilot v0.9.7. After the
fix, toggling RecordFront off in settings survives re-training.