### PR TITLE
fix: mazda safety build error (sizeof-pointer-div)

### DIFF
--- a/panda/board/safety/safety_mazda.h
+++ b/panda/board/safety/safety_mazda.h
@@ -323,7 +323,7 @@ static safety_config mazda_init(uint16_t param) {
     } else if (radar_interceptor) {
       SET_TX_MSGS(MAZDA_RI_TX_MSGS, ret);
     } else if (torque_interceptor) {
-      SET_RX_CHECKS(no_mrcc ? mazda_ti_no_mrcc_rx_checks : mazda_ti_rx_checks, ret);
+      if (no_mrcc) { SET_RX_CHECKS(mazda_ti_no_mrcc_rx_checks, ret); } else { SET_RX_CHECKS(mazda_ti_rx_checks, ret); }
       SET_TX_MSGS(MAZDA_TI_TX_MSGS, ret);
     } else {
       SET_TX_MSGS(MAZDA_TX_MSGS, ret);


### PR DESCRIPTION
SET_RX_CHECKS uses sizeof(rx)/sizeof(rx[0]) to get the array length, but the ternary on line 326 decays both arrays to pointers. gcc catches this with -Werror=sizeof-pointer-div and the build fails.

Replaced with if/else so each macro call gets the actual array.