### PR TITLE
locationd: permanent no-GPS mode + finite-check fix for lateral drift

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -153,7 +153,6 @@ class Controls:
     self.cruise_mismatch_counter = 0
     self.last_blinker_frame = 0
     self.last_steering_pressed_frame = 0
-    self.distance_traveled = 0
     self.last_functional_fan_frame = 0
     self.events_prev = []
     self.current_alert_types = [ET.PERMANENT]
@@ -438,12 +437,10 @@ class Controls:
 
     # TODO: fix simulator
     if not SIMULATION or REPLAY:
-      # Not show in first 1 km to allow for driving out of garage. This event shows after 5 minutes
-      if not self.sm['liveLocationKalman'].gpsOK and self.sm['liveLocationKalman'].inputsOK and (self.distance_traveled > 1500):
-        self.events.add(EventName.noGps)
-      if self.sm['liveLocationKalman'].gpsOK:
-        self.distance_traveled = 0
-      self.distance_traveled += CS.vEgo * DT_CTRL
+      # Drift-debug fix (B): locationd no longer subscribes to GPS, so gpsOK is
+      # permanently false and this alert would show on every drive after 1.5 km.
+      # GPS is out of the control chain entirely; drop the alert like upstream
+      # did in the 0.9.8 no-GPS rewrite.
 
       if self.sm['modelV2'].frameDropPerc > 20:
         self.events.add(EventName.modeldLagging)

--- a/selfdrive/locationd/locationd.cc
+++ b/selfdrive/locationd/locationd.cc
@@ -560,7 +560,12 @@ void Localizer::reset_kalman(double current_time) {
 }
 
 void Localizer::finite_check(double current_time) {
-  bool all_finite = this->kf->get_x().array().isFinite().all() or this->kf->get_P().array().isFinite().all();
+  // Drift-debug fix (A): upstream wrote `or` here, which meant the guard only
+  // tripped when BOTH x and P went non-finite. We saw P go to NaN
+  // (positionECEFStd=NaN in drift_debug snapshots) while x stayed finite —
+  // status then sticks at UNINITIALIZED forever because NaN < VALID_POS_STD
+  // and NaN > SANE_GPS_UNCERTAINTY are both false, so no recovery path fires.
+  bool all_finite = this->kf->get_x().array().isFinite().all() and this->kf->get_P().array().isFinite().all();
   if (!all_finite) {
     LOGE("Non-finite values detected, kalman reset");
     this->reset_kalman(current_time);
@@ -772,6 +777,14 @@ int Localizer::locationd_thread() {
       bool inputsOK = sm.allValid() && this->are_inputs_ok();
       bool gpsOK = this->is_gps_ok();
       bool sensorsOK = sm.allAliveAndValid({"accelerometer", "gyroscope"});
+
+      // Drift-debug fix (A): keep pos_std bounded while GPS is absent.
+      // Existing determine_gps_mode only inputs fake obs once pos_std > 1500m,
+      // leaving a 50–1500m "stuck zone" where pos_std drifts up freely and
+      // status pins at UNINITIALIZED. Run fake obs every tick without GPS.
+      if (filterInitialized && !gpsOK) {
+        this->input_fake_gps_observations(this->kf->get_filter_time());
+      }
 
       // Log time to first fix
       if (gpsOK && std::isnan(this->ttff) && !std::isnan(this->first_valid_log_time)) {

--- a/selfdrive/locationd/locationd.cc
+++ b/selfdrive/locationd/locationd.cc
@@ -734,21 +734,21 @@ void Localizer::configure_gnss_source(const LocalizerGnssSource &source) {
 
 int Localizer::locationd_thread() {
   Params params;
-  LocalizerGnssSource source;
-  const char* gps_location_socket;
-  if (params.getBool("UbloxAvailable")) {
-    source = LocalizerGnssSource::UBLOX;
-    gps_location_socket = "gpsLocationExternal";
-  } else {
-    source = LocalizerGnssSource::QCOM;
-    gps_location_socket = "gpsLocation";
-  }
-
-  this->configure_gnss_source(source);
-  const std::initializer_list<const char *> service_list = {gps_location_socket, "cameraOdometry", "liveCalibration",
+  // Drift-debug fix (B): permanent no-GPS mode.
+  // Don't subscribe to any GPS source so handle_gps / handle_gnss never run.
+  // gps_mode stays at its default false (locationd.h initializer) and
+  // last_gps_msg stays 0, so is_gps_ok() always returns false → A's
+  // input_fake_gps_observations path in the main loop runs every tick and
+  // keeps pos_std bounded purely from inertial integration. The locationd
+  // pose stream (calibratedOrientationNED / velocityCalibrated /
+  // angularVelocityCalibrated) is unaffected — those use `this->calibrated`,
+  // not `gps_mode`. Conceptually equivalent to upstream PR #33029 in intent,
+  // without the C++→Python rewrite. Inspired by drift_debug snapshots where
+  // GPS dropouts pinned status at UNINITIALIZED.
+  const std::initializer_list<const char *> service_list = {"cameraOdometry", "liveCalibration",
                                                           "carState", "accelerometer", "gyroscope"};
 
-  SubMaster sm(service_list, {}, nullptr, {gps_location_socket});
+  SubMaster sm(service_list);
   PubMaster pm({"liveLocationKalman", "livePose"});
 
   uint64_t cnt = 0;


### PR DESCRIPTION
## Goal

Fix lateral drift caused by locationd's EKF on Mazda (no native yawRate).
On GPS dropouts the position covariance (`positionECEFStd`) goes NaN and the
localizer status sticks at `UNINITIALIZED` forever, so the pose used by the
controller drifts.

## Changes

**(A) `locationd.cc` — finite guard + active fake observations**
- `finite_check`: `or` → `and`. The original condition only reset the Kalman
  filter when *both* `x` and `P` were non-finite. In practice `P` went NaN
  while `x` stayed finite, so no recovery ever fired (`NaN < VALID_POS_STD`
  and `NaN > SANE_GPS_UNCERTAINTY` are both false).
- Feed `input_fake_gps_observations` every tick while GPS is absent, instead
  of only once `pos_std > 1500 m`. This removes the 50-1500 m "stuck zone"
  where `pos_std` drifts up unbounded and status pins at `UNINITIALIZED`.

**(B) `locationd.cc` + `controlsd.py` — permanent no-GPS mode**
- locationd no longer subscribes to any GPS source, so `is_gps_ok()` is always
  false and the fake-observation path keeps `pos_std` bounded from inertial
  integration alone. The pose stream (orientation/velocity/angular velocity)
  is unaffected - it depends on `this->calibrated`, not `gps_mode`.
  Conceptually equivalent to upstream PR #33029, without the C++->Python rewrite.
- controlsd: drop the `noGps` alert, which would otherwise show on every drive
  past 1.5 km now that `gpsOK` is permanently false.

## Testing

On-device validation (2026-06-10): under permanent no-GPS, localizer
`status == valid` with zero Kalman resets across the route. No lateral drift
observed.

<!-- TODO: add route / dongle ID before marking ready for review -->
