### PR TITLE
Fix infinite "Update Required" loop on comma 4 AGNOS installation

### DIFF
--- a/launch_env.sh
+++ b/launch_env.sh
@@ -21,7 +21,11 @@ fi
 export QCOM_PRIORITY=12
 
 if [ -z "$AGNOS_VERSION" ]; then
-  export AGNOS_VERSION="12.8.16"
+  export AGNOS_VERSION="12.8.28"
+fi
+
+if [ -z "$AGNOS_ACCEPTED_VERSIONS" ]; then
+  export AGNOS_ACCEPTED_VERSIONS="$AGNOS_VERSION"
 fi
 
 export STAGING_ROOT="/data/safe_staging"

--- a/system/hardware/tici/agnos.json
+++ b/system/hardware/tici/agnos.json
@@ -67,13 +67,12 @@
   },
   {
     "name": "system",
-    "url": "https://www.dropbox.com/scl/fi/uglf3j1ne3pqtlx8j4mzp/system2.img.xz?rlkey=t1dp8rmyv6kuiyagy4p02ah6q&st=iai09tjz&dl=1",
-    "hash": "06641f9fb602e6b046d1a619cc43dbaa724ff5c3700a32f1ef6677e40146359e",
-    "hash_raw": "06641f9fb602e6b046d1a619cc43dbaa724ff5c3700a32f1ef6677e40146359e",
+    "url": "https://www.dropbox.com/scl/fi/8fd3w7hbhsyq146kqqdab/system8.img.xz?rlkey=5zt15mtuehdlj8ncj6pwn7zjy&st=j6tr4d47&dl=1",
+    "hash": "4c01245932068aedfceb41cb1aab1f7f044f6659aa2fe2de558f99e2d3aa5793",
+    "hash_raw": "4c01245932068aedfceb41cb1aab1f7f044f6659aa2fe2de558f99e2d3aa5793",
     "size": 5368709120,
     "sparse": false,
     "full_check": false,
-    "has_ab": true,
-    "ondevice_hash": "242aa5adad1c04e1398e00e2440d1babf962022eb12b89adf2e60ee3068946e7"
+    "has_ab": true
   }
 ]


### PR DESCRIPTION
## Problem

Installing this fork on a comma 4 device resulted in an infinite "Update Required" loop:

1. The AGNOS OS update (~1GB) would download and reach ~80% installation progress
2. The device would reboot into the newly flashed OS
3. The "Update Required" screen would immediately appear again
4. Repeat indefinitely

## Root Cause (two separate issues)

**1. Broken system image URL in `agnos.json`**

The `system` partition entry pointed to `system2.img.xz` via a Dropbox shared link that
has since expired. The link returns an HTML error page (`text/html`) instead of the binary
image, causing hash verification to fail on some devices/conditions.

The upstream `firestar5683/StarPilot` repo had already fixed this by bumping to
`system8.img.xz` in commit `a51b1fd` ("Omnioculars V1", 2026-07-20), but that fix was
not yet merged into this branch.

**2. `AGNOS_VERSION` mismatch in `launch_env.sh`**

`launch_env.sh` still declared `AGNOS_VERSION="12.8.16"`, while `system8.img.xz`
contains AGNOS `12.8.28`. After successfully flashing the image, `updated.py` compares
the on-device OS version against `AGNOS_VERSION` from `launch_env.sh`:

```python
cur_version = HARDWARE.get_os_version()   # → "12.8.28" (freshly flashed)
updated_version = ...AGNOS_VERSION...     # → "12.8.16" (from launch_env.sh)
if cur_version == updated_version:        # → False → triggers update loop again
